### PR TITLE
fix: module name

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/AcordoCertoBR/streamsurfer
+module github.com/AcordoCertoBR/streamsurfer/v2
 
 go 1.23
 


### PR DESCRIPTION
This pull request makes a small but important change to the module path in the `go.mod` file, updating it to use Go module versioning conventions for version 2.

* Updated the module path in `go.mod` from `github.com/AcordoCertoBR/streamsurfer` to `github.com/AcordoCertoBR/streamsurfer/v2` to comply with Go's semantic import versioning for major version updates.