### PR TITLE
Fix: optimizing methods

### DIFF
--- a/main.go
+++ b/main.go
@@ -273,16 +273,18 @@ func (q *kinesisQueue) sendToKinesis(data []any) ([]any, error) {
 func (q *kinesisQueue) drainItems() []any {
 	var items []any
 
-	for q.currentSize > 0 {
+	size := q.q.Len()
+
+	for range size {
 		val, err := q.q.Get(1)
 		if err != nil {
 			break
 		}
 
 		items = append(items, val[0])
-		itemBytes, _ := json.Marshal(val[0])
-		q.currentSize -= len(itemBytes)
 	}
+
+	q.currentSize = 0
 
 	return items
 }

--- a/main.go
+++ b/main.go
@@ -63,6 +63,22 @@ func NewWithOrigin(streamName string, origin string) (*kinesisQueue, error) {
 	return NewWithOpts(streamName, "sa-east-1", 1024, origin, "")
 }
 
+// NewWithOriginAndMaxSize creates a new KinesisQueue for sending messages in a batch to a Kinesis stream.
+//
+// Parameters:
+//
+//	streamName: the name of the Kinesis stream to send messages to.
+//	origin: the app name that will be used to identify the origin of the messages.
+//	maxSizeBytes: the maximum size in bytes for the batch.
+//
+// Returns:
+//
+//	*kinesisQueue: a pointer to the concrete kinesisQueue implementation.
+//	error: an error, if any occurred during the creation.
+func NewWithOriginAndMaxSize(streamName string, origin string, maxSizeBytes int) (*kinesisQueue, error) {
+	return NewWithOpts(streamName, "sa-east-1", maxSizeBytes, origin, "")
+}
+
 // NewWithStreamArn creates a new KinesisQueue for sending messages in a batch to a Kinesis stream
 // using the stream ARN. This method is useful to send messages to a stream in a different account.
 //
@@ -102,7 +118,7 @@ func extractStreamNameFromARN(arn string) (string, error) {
 //
 //	streamName: the name of the Kinesis stream to send messages to.
 //	region: the aws region. The default is sa-east-1.
-//	maxSizeKB: the maximum size in kilobytes for the batch.
+//	maxSizeBytes: the maximum size in bytes for the batch.
 //	origin: the app name that will be used to identify the origin of the messages.
 //	streamArn: the ARN of the Kinesis stream to send messages to.
 //
@@ -110,7 +126,7 @@ func extractStreamNameFromARN(arn string) (string, error) {
 //
 //	*kinesisQueue: a pointer to the concrete kinesisQueue implementation.
 //	error: an error, if any occurred during the creation.
-func NewWithOpts(streamName string, region string, maxSizeKB int, origin string, streamArn string) (*kinesisQueue, error) {
+func NewWithOpts(streamName string, region string, maxSizeBytes int, origin string, streamArn string) (*kinesisQueue, error) {
 	if streamName == "" {
 		return &kinesisQueue{}, fmt.Errorf("streamName must be provided")
 	}
@@ -119,8 +135,8 @@ func NewWithOpts(streamName string, region string, maxSizeKB int, origin string,
 		region = "sa-east-1"
 	}
 
-	if maxSizeKB == 0 {
-		return &kinesisQueue{}, fmt.Errorf("maxSizeKB must be provided")
+	if maxSizeBytes == 0 {
+		return &kinesisQueue{}, fmt.Errorf("maxSizeBytes must be provided")
 	}
 
 	kinesisClient, err := connectToKinesis(region)
@@ -130,7 +146,7 @@ func NewWithOpts(streamName string, region string, maxSizeKB int, origin string,
 
 	q := &kinesisQueue{
 		q:             queue.New(0),
-		maxSizeBytes:  maxSizeKB,
+		maxSizeBytes:  maxSizeBytes,
 		lock:          &sync.RWMutex{},
 		kinesisClient: kinesisClient,
 		streamName:    streamName,


### PR DESCRIPTION
This pull request refactors the batch processing logic of the `kinesisQueue` in `main.go` to improve concurrency handling and code clarity. The most important changes are the introduction of a new `drainItems` method to safely clear the queue, the removal of the old `flush` implementation, and updates to locking and flushing logic in the `Enqueue` and `Flush` methods.

**Queue management and concurrency improvements:**

* Introduced the `drainItems` method to remove all items from the internal queue and reset `currentSize`, ensuring the caller holds the queue lock for thread safety. (`main.go`)
* Refactored the `Enqueue` method to use `drainItems` for batch flushing, improved lock handling by explicitly locking/unlocking around critical sections, and ensured items are sent to Kinesis after unlocking. (`main.go`)

**Codebase simplification:**

* Removed the old private `flush` method and replaced its logic with `drainItems`, reducing code duplication and improving maintainability. (`main.go`)
* Updated the public `Flush` method to use `drainItems` and perform queue unlocking before sending items to Kinesis, improving concurrency and code clarity. (`main.go`)

** About ordering**

* Ordering does not matter, because received_timestamp is based on server_timestamp.